### PR TITLE
jenkinsx-test-python-app to 0.0.7

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,4 +9,4 @@ dependencies:
   version: 2.3.89
 - name: jenkinsx-test-python-app
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.6
+  version: 0.0.7


### PR DESCRIPTION
Promote jenkinsx-test-python-app to version 0.0.7