### PR TITLE
jenkinsx-test-python-app to 0.0.9

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
   version: 2.3.89
 - name: jenkinsx-test-python-app
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.8
+  version: 0.0.9
 - name: jx-test-py2
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.7


### PR DESCRIPTION
Promote jenkinsx-test-python-app to version 0.0.9